### PR TITLE
Add support for go1.20, read atomic.Int32 from reflect.Value

### DIFF
--- a/mutex.go
+++ b/mutex.go
@@ -19,5 +19,5 @@ func RWMutexLocked(rw *sync.RWMutex) bool {
 }
 
 func RWMutexRLocked(rw *sync.RWMutex) bool {
-	return reflect.ValueOf(rw).Elem().FieldByName("readerCount").Int() > 0
+	return readerCount(rw) > 0
 }

--- a/readercount_go120.go
+++ b/readercount_go120.go
@@ -1,0 +1,18 @@
+//go:build go1.20
+// +build go1.20
+
+package mutexasserts
+
+import (
+	"reflect"
+	"sync"
+	"sync/atomic"
+)
+
+// Starting in go1.20, readerCount is an atomic int32 value.
+// See: https://go-review.googlesource.com/c/go/+/429767
+func readerCount(rw *sync.RWMutex) int64 {
+	// Look up the address of the readerCount field and use it to create a pointer to an atomic.Int32,
+	// then load the value to return.
+	return int64((*atomic.Int32)(reflect.ValueOf(rw).Elem().FieldByName("readerCount").Addr().UnsafePointer()).Load())
+}

--- a/readercount_go120.go
+++ b/readercount_go120.go
@@ -14,5 +14,6 @@ import (
 func readerCount(rw *sync.RWMutex) int64 {
 	// Look up the address of the readerCount field and use it to create a pointer to an atomic.Int32,
 	// then load the value to return.
-	return int64((*atomic.Int32)(reflect.ValueOf(rw).Elem().FieldByName("readerCount").Addr().UnsafePointer()).Load())
+	rc := (*atomic.Int32)(reflect.ValueOf(rw).Elem().FieldByName("readerCount").Addr().UnsafePointer())
+	return int64(rc.Load())
 }

--- a/readercount_legacy.go
+++ b/readercount_legacy.go
@@ -1,0 +1,14 @@
+//go:build !go1.20
+// +build !go1.20
+
+package mutexasserts
+
+import (
+	"reflect"
+	"sync"
+)
+
+// Prior to go1.20, readerCount was an int value.
+func readerCount(rw *sync.RWMutex) int64 {
+	return reflect.ValueOf(rw).Elem().FieldByName("readerCount").Int()
+}


### PR DESCRIPTION
Fixes #1

Tested with gotip version
```
go version devel go1.20-db36eca Thu Dec 29 23:36:05 2022 +0000 linux/amd64
```
