### PR TITLE
fix(go.mod): revert Go version to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/trailofbits/go-mutexasserts
 
-go 1.24
+go 1.20


### PR DESCRIPTION
The go.mod version specifies the minimum required Go version, not the target version.
This change reverts from 1.24 to 1.20 to better reflect actual compatibility.

For more information on go.mod versioning, see:
https://go.dev/doc/modules/gomod-ref#go

Furthermore, I noticed that this codebase historically attempted to support Go versions as early as 1.11 (see [commit 8cdbc5f](https://github.com/trailofbits/go-mutexasserts/commit/8cdbc5f3d279990c5145624c3c4eb5918fe18023)). While this PR sets the minimum version to 1.20, we might consider using 1.11 instead if backward compatibility is a priority.

According to the [Go modules reference](https://go.dev/doc/modules/gomod-ref#go), the `go` directive specifies the minimum Go version required to use the module and affects:

1. Which language features can be used in the module
2. How the compiler handles errors
3. Certain `go` command behaviors

If there are no language features or behaviors from Go 1.20 that this module depends on, and if supporting older Go versions is desirable, we could consider lowering the version further. However, Go 1.20 is a reasonable minimum for modern libraries, as it ensures proper module support.

Let me know if you'd prefer to maintain compatibility with even older Go versions, and we can adjust accordingly.

Signed-off-by: Kemal Akkoyun <kemal.akkoyun@datadoghq.com>
